### PR TITLE
FIX: Managed Subnet NSG Assocation

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version = "5.0.1"
+  hashes = [
+    "h1:aKeAcquycUNwunVi03Td6Oyyxoap0jNrErDN+p47mYc=",
+    "zh:2de9caf937237bf5ee747b803b15a08276ceb275f611f6444fca3d82fc75afec",
+    "zh:3b1915d0c391a8e0bdce66bf603e30fff230f67667161de9c143ca8ce37539a1",
+    "zh:3c45e7833218734ca5ed321e799a8d8abed6801e27397eb106d0f55dfb1eaa87",
+    "zh:3dd2db3ddc9e26108274c567bafe474a4df930ec719074cd545fe39dde6ac206",
+    "zh:5d82dd9533b0b153894fb2432a36d3c3505ab27a879338c62e70bda15ba97f8c",
+    "zh:78562c75f27b75e4a5f854dc290b7c1c262ebdf2354ca16a110b841ca697bf90",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b73ea687a28ed51823d716f46cafd4236ca50ca172558ec5aa18c132c206620",
+    "zh:95e572793efef127b773c35e1581e462e97fb38cf696bc6caf53c1231e21a36c",
+    "zh:c1a95c6917689be45e1a6408f8a05c8a4a7a628427b795931fabea4e43e95742",
+    "zh:c7281424d802a12ebd41297c68f3008602ac3c2ad98fc25937654014902b37eb",
+    "zh:dd98c2c8eb092f29cba261065bbaa7e917e8336f8fc4e0ea25e642f7b90c962e",
+  ]
+}

--- a/example/outputs.tf
+++ b/example/outputs.tf
@@ -3,9 +3,9 @@ output "virtual_network_id" {
   value       = module.core_network.virtual_network_id
 }
 
-output "subnet_ids" {
+output "subnets" {
   description = "Map output of subnet IDs created by the module."
-  value       = module.core_network.subnet_ids
+  value       = module.core_network.subnets
 }
 
 output "nsgs" {

--- a/example/outputs.tf
+++ b/example/outputs.tf
@@ -8,16 +8,6 @@ output "subnet_ids" {
   value       = module.core_network.subnet_ids
 }
 
-output "private_endpoint_subnet_id" {
-  description = "Private Endpoint Subnet ID"
-  value       = module.core_network.subnet_ids["pe"]
-}
-
-output "web_subnet_id" {
-  description = "Web Subnet ID"
-  value       = module.core_network.subnet_ids["web"]
-}
-
 output "nsg_ids" {
   description = "The IDs of the Network Security Groups created by the module"
   value       = module.core_network.nsg_ids

--- a/example/outputs.tf
+++ b/example/outputs.tf
@@ -8,7 +8,7 @@ output "subnet_ids" {
   value       = module.core_network.subnet_ids
 }
 
-output "nsg_ids" {
-  description = "The IDs of the Network Security Groups created by the module"
-  value       = module.core_network.nsg_ids
+output "nsgs" {
+  description = "A map containing the information of the NSGs deployed by the module"
+  value       = module.core_network.nsgs
 }

--- a/example/providers.tf
+++ b/example/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.9.3"
+  required_version = "~> 1.15.8"
 
   required_providers {
     azurerm = {

--- a/example/variables.tf
+++ b/example/variables.tf
@@ -52,6 +52,7 @@ variable "subnets" {
     private_endpoint_network_policies             = optional(string, "Disabled")
     private_link_service_network_policies_enabled = optional(bool, false)
     service_endpoints                             = optional(list(string), [])
+    managed                                       = optional(bool, false)
     delegation = optional(object({
       name = string
       service_delegation = object({

--- a/example/vars/dev-uksouth.tfvars
+++ b/example/vars/dev-uksouth.tfvars
@@ -21,8 +21,8 @@ subnets = {
   pe = {
     address_prefix                                = "10.0.0.32/29"
     private_link_service_network_policies_enabled = true
-  },
-
+    managed                                       = true
+  }
 }
 
 dns_servers = ["10.0.0.0", "10.0.0.1"]

--- a/locals.tf
+++ b/locals.tf
@@ -1,9 +1,9 @@
 locals {
-    managed_subnet_names = [
-        "GatewaySubnet",
-        "AzureFirewallSubnet",
-        "AzureFirewallManagementSubnet",
-        "AzureBastionSubnet",
-        "RouteServerSubnet"
-    ]
+  managed_subnet_names = [
+    "GatewaySubnet",
+    "AzureFirewallSubnet",
+    "AzureFirewallManagementSubnet",
+    "AzureBastionSubnet",
+    "RouteServerSubnet"
+  ]
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,9 @@
+locals {
+    managed_subnet_names = [
+        "GatewaySubnet",
+        "AzureFirewallSubnet",
+        "AzureFirewallManagementSubnet",
+        "AzureBastionSubnet",
+        "RouteServerSubnet"
+    ]
+}

--- a/main.tf
+++ b/main.tf
@@ -33,15 +33,15 @@ resource "azurerm_subnet" "this" {
 }
 
 resource "azurerm_network_security_group" "this" {
-  for_each = var.subnets
-
+  for_each = {for k, v in var.subnets: k => v if (v.managed != true && !contains(local.managed_subnet_names, k))}
+  
   name                = join("-", ["nsg", each.key])
   location            = var.location
   resource_group_name = var.resource_group_name
 }
 
 resource "azurerm_subnet_network_security_group_association" "this" {
-  for_each = var.subnets
+  for_each = {for k, v in var.subnets: k => v if (v.managed != true && !contains(local.managed_subnet_names, k))}
 
   subnet_id                 = azurerm_subnet.this[each.key].id
   network_security_group_id = azurerm_network_security_group.this[each.key].id

--- a/main.tf
+++ b/main.tf
@@ -33,15 +33,15 @@ resource "azurerm_subnet" "this" {
 }
 
 resource "azurerm_network_security_group" "this" {
-  for_each = {for k, v in var.subnets: k => v if (v.managed != true && !contains(local.managed_subnet_names, k))}
-  
+  for_each = { for k, v in var.subnets : k => v if(v.managed != true && !contains(local.managed_subnet_names, k)) }
+
   name                = join("-", ["nsg", each.key])
   location            = var.location
   resource_group_name = var.resource_group_name
 }
 
 resource "azurerm_subnet_network_security_group_association" "this" {
-  for_each = {for k, v in var.subnets: k => v if (v.managed != true && !contains(local.managed_subnet_names, k))}
+  for_each = { for k, v in var.subnets : k => v if(v.managed != true && !contains(local.managed_subnet_names, k)) }
 
   subnet_id                 = azurerm_subnet.this[each.key].id
   network_security_group_id = azurerm_network_security_group.this[each.key].id

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,7 +8,7 @@ output "subnet_ids" {
   value       = zipmap([for k, v in var.subnets : k], [for k, v in var.subnets : azurerm_subnet.this[k].id])
 }
 
-output "nsg_ids" {
-  description = "Zipmap output of Network Security Group IDs created by the module"
-  value       = zipmap([for k, v in var.subnets : k if (v.managed != true && !contains(local.managed_subnet_names, k))], [for k, v in var.subnets : azurerm_network_security_group.this[k].id if (v.managed != true && !contains(local.managed_subnet_names, k))])
+output "nsgs" {
+  description = "The network security groups created by the module."
+  value       = azurerm_network_security_group.this
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,5 +10,5 @@ output "subnet_ids" {
 
 output "nsg_ids" {
   description = "Zipmap output of Network Security Group IDs created by the module"
-  value       = zipmap([for k, v in var.subnets : k], [for k, v in var.subnets : azurerm_network_security_group.this[k].id])
+  value       = zipmap([for k, v in var.subnets : k if (v.managed != true && !contains(local.managed_subnet_names, k))], [for k, v in var.subnets : azurerm_network_security_group.this[k].id if (v.managed != true && !contains(local.managed_subnet_names, k))])
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,9 +3,9 @@ output "virtual_network_id" {
   value       = azurerm_virtual_network.this.id
 }
 
-output "subnet_ids" {
+output "subnets" {
   description = "Zipmap output of subnet IDs created by the module."
-  value       = zipmap([for k, v in var.subnets : k], [for k, v in var.subnets : azurerm_subnet.this[k].id])
+  value       = azurerm_subnet.this
 }
 
 output "nsgs" {

--- a/variables.tf
+++ b/variables.tf
@@ -54,6 +54,7 @@ variable "subnets" {
     private_endpoint_network_policies             = optional(string, "Disabled")
     private_link_service_network_policies_enabled = optional(bool, false)
     service_endpoints                             = optional(list(string), [])
+    managed                                       = optional(bool, false)
     delegation = optional(object({
       name = optional(string)
       service_delegation = object({


### PR DESCRIPTION
## Changes
- Bumped Terraform Version in example to 1.15.8
- Added support for managed subnets not requiring network security group association
- BREAKING: Minor fixes to outputs - no longer having specific outputs for ID, return whole resource ref instead